### PR TITLE
Resolve a crash in `get_header`

### DIFF
--- a/nanowww.h
+++ b/nanowww.h
@@ -138,7 +138,7 @@ namespace nanowww {
             if (iter != headers_.end()) {
                 return iter->second[0];
             }
-            return NULL;
+            return std::string();
         }
         inline std::string as_string() {
             std::string res;


### PR DESCRIPTION
This method is currently crashing for us, we have resolved it by always returning a string, matching the guarantee of the function definition.
